### PR TITLE
MAE-173: Add a dummy payment processor when extension is installed

### DIFF
--- a/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
+++ b/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class to create dummy payment processor for membership extras.
+ */
+
+class CRM_Membershipextrasdefaultconfig_Setup_CreateDummyPaymentProcessorStep {
+
+  const PAYMENT_PROCESSOR_NAME = 'Test Payment Processor';
+
+  /**
+   * Main method that will apply all changes.
+   * This is called inside public function install of
+   * class CRM_Membershipextrasdefaultconfig_Upgrader
+   */
+  public function apply() {
+    if($this->paymentProcessorExists()) {
+      return;
+    }
+
+    // create entry with test details.
+    $this->createDummyPaymentProcessor(TRUE);
+
+    // create entry with live details.
+    $this->createDummyPaymentProcessor(FALSE);
+  }
+
+  /**
+   * Create Dummy payment processor for membershipextras.
+   */
+  private function createDummyPaymentProcessor($isTest) {
+    civicrm_api3('PaymentProcessor', 'create', [
+      'payment_processor_type_id' => 'Dummy',
+      'is_active' => 1,
+      'is_test' => $isTest,
+      'is_recur' => 1,
+      'domain_id' => CIVICRM_DOMAIN_ID,
+      'name' => self::PAYMENT_PROCESSOR_NAME,
+      'description' => self::PAYMENT_PROCESSOR_NAME,
+      'user_name' => 'username',
+      'url_site' => 'https://dummy.com',
+      'url_recur' => 'https://dummy.com',
+      'accepted_credit_cards' => '{"Visa":"Visa","MasterCard":"MasterCard","Amex":"Amex","Discover":"Discover"}',
+    ]);
+  }
+
+  /**
+   * Check if payment processor already exists.
+   */
+  private function paymentProcessorExists() {
+    $paymentProcessorCount =  civicrm_api3('PaymentProcessor', 'getcount', [
+      'name' => self::PAYMENT_PROCESSOR_NAME,
+    ]);
+
+    return $paymentProcessorCount;
+  }
+
+}

--- a/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
+++ b/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
@@ -8,11 +8,6 @@ class CRM_Membershipextrasdefaultconfig_Setup_CreateDummyPaymentProcessorStep {
 
   const PAYMENT_PROCESSOR_NAME = 'Test Payment Processor';
 
-  /**
-   * Main method that will apply all changes.
-   * This is called inside public function install of
-   * class CRM_Membershipextrasdefaultconfig_Upgrader
-   */
   public function apply() {
     if($this->paymentProcessorExists()) {
       return;

--- a/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
+++ b/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
@@ -13,10 +13,7 @@ class CRM_Membershipextrasdefaultconfig_Setup_CreateDummyPaymentProcessorStep {
       return;
     }
 
-    // create entry with test details.
     $this->createDummyPaymentProcessor(TRUE);
-
-    // create entry with live details.
     $this->createDummyPaymentProcessor(FALSE);
   }
 

--- a/CRM/Membershipextrasdefaultconfig/Upgrader.php
+++ b/CRM/Membershipextrasdefaultconfig/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 use CRM_Membershipextrasdefaultconfig_ExtensionUtil as E;
 use CRM_Membershipextrasdefaultconfig_Setup_CreateSampleContributionPageStep as CreateSampleContributionPageStep;
+use CRM_Membershipextrasdefaultconfig_Setup_CreateDummyPaymentProcessorStep as CreateDummyPaymentProcessorStep;
 
 /**
  * Collection of upgrade steps.
@@ -9,6 +10,7 @@ class CRM_Membershipextrasdefaultconfig_Upgrader extends CRM_Membershipextrasdef
 
   public function Install() {
     $steps = [
+      new CreateDummyPaymentProcessorStep(),
       new CreateSampleContributionPageStep(),
     ];
 


### PR DESCRIPTION
**Overview**
Create a dummy payment processor when membershipextrasdefaultconfig extension is installed.

**Before**
No dummy payment processor was created when extension was installed.

**After**
A new dummy payment processor with name "Test Payment Processor" will be created (if it doesnt exist) during installation.

**Technical Steps**
Added a setup class named: _CreateDummyPaymentProcessorStep_ which first checks if the  payment processor with same name exists. If it doesnt exist, it creates the payment processor.
_Please note that two entries need to be made for creating a payment processor, one with is_test = 0 and another with is_test =  1 (which means with live details)._