### PR TITLE
MAE-173: changed order of creating test and live payment processor entry

### DIFF
--- a/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
+++ b/CRM/Membershipextrasdefaultconfig/Setup/CreateDummyPaymentProcessorStep.php
@@ -13,8 +13,8 @@ class CRM_Membershipextrasdefaultconfig_Setup_CreateDummyPaymentProcessorStep {
       return;
     }
 
-    $this->createDummyPaymentProcessor(TRUE);
     $this->createDummyPaymentProcessor(FALSE);
+    $this->createDummyPaymentProcessor(TRUE);
   }
 
   /**


### PR DESCRIPTION
**Overview**
When creating compuclient sample contribution page, the test payment processor was not being attached to it. This PR fixes that.

**Before**
Test Payment Processor was not enabled on Compuclient sample contribution page.

**After**
Test Payment Processor is enabled on Compuclient sample contribution page.

**Technical Details**
If you create payment processor entry with test details first and then create entry with live details, it stops enabling it when Contribution page is created using API.
Payment processor entry need to be created in following order:
1. Test details entry.
2. Live details entry.